### PR TITLE
[Style] category 페이지 UI & LiquorCard UI 변경

### DIFF
--- a/app/liquor/search/result/page.tsx
+++ b/app/liquor/search/result/page.tsx
@@ -1,30 +1,29 @@
 "use client";
+
 import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import { Liquor } from "models/liquor";
 import { useLiquorSearch } from "apis/liquor/useLiquorSearch";
 import SearchInput from "components/liquor/search/SearchInput";
 import SortDropDown from "components/liquor/search/SortDropDown";
 import LiquorCard from "components/shared/LiquorCard";
 import FilterButton from "components/liquor/search/FilterButton";
-import { Suspense } from "react";
 import NoResultSection from "components/liquor/search/section/NoResultSection";
 
-// SearchParamsHandler 컴포넌트
-function SearchParamsHandler({
-  children,
-}: {
+type SearchParamsHandlerProps = {
   children: (params: URLSearchParams) => React.ReactNode;
-}) {
+};
+
+function SearchParamsHandler({ children }: SearchParamsHandlerProps) {
   const searchParams = useSearchParams();
   return <>{children(new URLSearchParams(searchParams.toString()))}</>;
 }
 
-// LiquorSearchContent 컴포넌트
-function LiquorSearchContent({
-  searchParams,
-}: {
+type LiquorSearchContentProps = {
   searchParams: URLSearchParams;
-}) {
+};
+
+function LiquorSearchContent({ searchParams }: LiquorSearchContentProps) {
   const { data, isLoading, error } = useLiquorSearch(
     {
       tag: searchParams.get("q") || undefined,
@@ -38,50 +37,68 @@ function LiquorSearchContent({
     searchParams.toString(),
   );
 
+  const liquorSubKey = searchParams.get("subKey");
   const liquors: Liquor[] = data?.data.content || [];
 
   if (!liquors.length) {
-    return (
-      <main className="flex min-h-screen flex-col">
-        <SearchInput />
-        <div className="flex flex-grow items-center justify-center">
-          <NoResultSection />
-        </div>
-      </main>
-    );
+    return <NoResultLayout liquorSubKey={liquorSubKey} />;
   }
 
   return (
     <main>
-      <SearchInput />
-      {/* 추천 목록 */}
-      <section className="border-b border-suldak-gray-200">
-        <div className="flex items-center gap-2 px-5 py-3.5">
-          <span className="text-sm font-semibold text-suldak-gray-900">
-            추천
-          </span>
-          <div className="text-suldak-gray-500">|</div>
-          <div className="flex items-center gap-4 text-sm font-semibold text-suldak-mint-500">
-            <span>직장인</span>
-            <span>위스키 베이스</span>
-            <span>칵테일</span>
-          </div>
-        </div>
-      </section>
+      {!liquorSubKey && <SearchInput />}
+      {!liquorSubKey && <RecommendationSection />}
+      <LiquorListSection liquors={liquors} liquorSubKey={liquorSubKey} />
+    </main>
+  );
+}
 
-      {/* 술 검색 목록 */}
+function NoResultLayout({ liquorSubKey }: { liquorSubKey: string | null }) {
+  return (
+    <main className="flex min-h-screen flex-col">
+      {!liquorSubKey && <SearchInput />}
+      <div className="flex flex-grow items-center justify-center">
+        <NoResultSection />
+      </div>
+    </main>
+  );
+}
+
+function RecommendationSection() {
+  return (
+    <section className="border-b border-suldak-gray-200">
+      <div className="flex items-center gap-2 px-5 py-3.5">
+        <span className="text-sm font-semibold text-suldak-gray-900">추천</span>
+        <div className="text-suldak-gray-500">|</div>
+        <div className="flex items-center gap-4 text-sm font-semibold text-suldak-mint-500">
+          <span>직장인</span>
+          <span>위스키 베이스</span>
+          <span>칵테일</span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type LiquorListSectionProps = {
+  liquors: Liquor[];
+  liquorSubKey: string | null;
+};
+
+function LiquorListSection({ liquors, liquorSubKey }: LiquorListSectionProps) {
+  return (
+    <>
       <section className="px-5">
         <div className="flex items-center justify-between pt-3.5">
           <span className="text-xs font-medium text-suldak-gray-600">
             총 {liquors.length ?? 0}종
           </span>
           <div className="flex items-center gap-3 text-sm font-medium leading-5 text-suldak-gray-600">
-            <SortDropDown />
-            <FilterButton />
+            {!liquorSubKey && <SortDropDown />}
+            {!liquorSubKey && <FilterButton />}
           </div>
         </div>
       </section>
-
       <section
         className="flex flex-col gap-2.5 overflow-y-auto px-5 py-3.5"
         style={{ maxHeight: `calc(100dvh - 100px)` }}
@@ -100,7 +117,7 @@ function LiquorSearchContent({
           />
         ))}
       </section>
-    </main>
+    </>
   );
 }
 

--- a/app/liquor/search/result/page.tsx
+++ b/app/liquor/search/result/page.tsx
@@ -36,7 +36,7 @@ function RecommendSection({
 }) {
   return (
     <section className="border-b border-suldak-gray-200">
-      <div className="flex items-center gap-2 px-5 py-3.5">
+      <div className="flex items-center gap-2 px-[20px] py-3.5">
         <span className="text-sm font-semibold text-suldak-gray-900">추천</span>
         {keywords.length > 0 && (
           <>
@@ -67,7 +67,7 @@ function SearchInfoSection({
   children: React.ReactNode;
 }) {
   return (
-    <section className="px-5">
+    <section className="h-[44px] px-[20px]">
       <div className="flex items-center justify-between pt-3.5">
         <span className="text-xs font-medium text-suldak-gray-600">
           총 {count}종
@@ -82,13 +82,13 @@ function SearchInfoSection({
 
 function LiquorList({ liquors }: { liquors: Liquor[] }) {
   return (
-    <section className="flex flex-col gap-2.5 overflow-y-auto px-5 py-3.5">
+    <section className="flex w-full flex-col items-center justify-center gap-y-2.5 overflow-y-auto">
       {liquors.map((liquor: Liquor) => (
         <LiquorCard
           key={liquor.id}
           imgUrl={liquor.liquorPictureUrl || "/default-image-url.jpg"}
           liquorId={liquor.id}
-          liquorDetail={liquor.detailExplanation}
+          liquorDetail={liquor.summaryExplanation}
           liquorAbv={liquor.detailAbv}
           name={liquor.name}
           liquorSellDtos={liquor.liquorSellDtos}
@@ -141,7 +141,7 @@ function LiquorSearchContent({
   }
 
   return (
-    <main className="flex min-h-screen flex-col">
+    <main className="flex min-h-screen flex-col pb-[10px]">
       {!liquorSubKey && <SearchInput />}
       {!liquorSubKey && (
         <RecommendSection keywords={keywords} onClick={handleKeywordClick} />
@@ -152,20 +152,23 @@ function LiquorSearchContent({
           <FilterButton />
         </SearchInfoSection>
       )}
-      <section className="flex flex-col gap-2.5 overflow-y-auto px-5 py-3.5">
-        {isLoading ? (
-          <>
-            <LoadingCard />
-            <LoadingCard />
-            <LoadingCard />
-            <LoadingCard />
-          </>
-        ) : liquors.length === 0 ? (
-          <NoResultSection />
-        ) : (
-          <LiquorList liquors={liquors} />
-        )}
-      </section>
+      {liquorSubKey && (
+        <SearchInfoSection count={isLoading ? 0 : liquors.length}>
+          <div />
+        </SearchInfoSection>
+      )}
+      {isLoading ? (
+        <section className="flex flex-col items-center justify-center gap-2.5 overflow-y-auto px-[20px]">
+          <LoadingCard />
+          <LoadingCard />
+          <LoadingCard />
+          <LoadingCard />
+        </section>
+      ) : liquors.length === 0 ? (
+        <NoResultSection />
+      ) : (
+        <LiquorList liquors={liquors} />
+      )}
     </main>
   );
 }

--- a/components/shared/LiquorCard/LoadingCard.tsx
+++ b/components/shared/LiquorCard/LoadingCard.tsx
@@ -1,9 +1,7 @@
 /** 카드 컴포넌트 */
 function LoadingCard() {
   return (
-    <div className="flex h-card w-full cursor-pointer items-center rounded-2xl bg-white p-[18px] text-black shadow-suldak-card">
-      <div className="mr-[14px] h-card-image min-w-card-image rounded-full bg-orange-500"></div>
-
+    <div className="flex h-[144px] w-[335px] cursor-pointer items-center rounded-[16px] bg-white p-[18px] text-black shadow-suldak-card">
       {/* 텍스트 영역 */}
       <div className="flex flex-col">
         <div className="flex flex-col">

--- a/components/shared/LiquorCard/index.tsx
+++ b/components/shared/LiquorCard/index.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
-/** 카드 컴포넌트 */
 function LiquorCard({
   imgUrl,
   liquorId,
@@ -25,37 +24,34 @@ function LiquorCard({
   // 모든 태그를 하나의 배열로 결합
   const allTags = [...liquorSellDtos, ...tasteTypeDtos, ...liquorSnackRes]
     .filter((item) => item?.name)
-    .slice(0, 4); // 최대 4개로 제한
+    .slice(0, 3); // 최대 4개로 제한
 
   return (
     <div
-      className="flex h-card w-full cursor-pointer items-center rounded-2xl bg-white p-[18px] text-black shadow-suldak-card"
+      className="flex h-[144px] w-[335px] cursor-pointer items-center text-wrap rounded-[16px] bg-white p-3 text-black shadow-suldak-card"
       onClick={handleClick}
     >
-      <div className="mr-[14px] h-card-image min-w-card-image rounded-full bg-orange-500">
+      <div className="mr-3 h-20 w-20 flex-shrink-0 mobile:mr-4 mobile:h-24 mobile:w-24">
         <Image
-          className="h-card-image w-card-image rounded-full bg-orange-500"
+          className="h-full w-full rounded-full object-cover"
           src={`${BASE_URL + imgUrl}`}
           alt="술 이미지"
-          width={100}
-          height={100}
+          width={96}
+          height={96}
         />
       </div>
 
-      {/* 텍스트 영역 */}
-      <div className="flex flex-col">
-        <div className="flex flex-col">
-          <p className="text-[12px] font-medium text-suldak-orange-500">
-            ALC {liquorAbv}%
-          </p>
-          <p className="text-[16px] font-semibold text-suldak-gray-900">
-            {name || "Name None"}
-          </p>
-          <p className="flex max-h-[38px] overflow-hidden text-[14px] text-suldak-gray-600">
-            {liquorDetail || "주류 정보 추가 예정입니다."}
-          </p>
-        </div>
-        <div className="mt-[2px] flex w-[193px] gap-x-[6px] overflow-hidden">
+      <div className="flex min-w-0 flex-grow flex-col">
+        <p className="text-xs font-medium text-suldak-orange-500 mobile:text-sm">
+          ALC {liquorAbv}%
+        </p>
+        <p className="truncate text-sm font-semibold text-suldak-gray-900 mobile:text-base">
+          {name || "Name None"}
+        </p>
+        <p className="mt-1 line-clamp-2 text-xs text-suldak-gray-600 mobile:text-sm">
+          {liquorDetail || "주류 정보 추가 예정입니다."}
+        </p>
+        <div className="mt-2 flex gap-1">
           {allTags.map((tag, index) => (
             <LiquorTag key={index} name={tag.name} />
           ))}


### PR DESCRIPTION
## 스크린샷
- 화면기획
<img width="309" alt="스크린샷 2024-10-12 오전 10 29 49" src="https://github.com/user-attachments/assets/4dc7c217-341d-4591-9da7-be0f7b20f0b9">

- 구현
<img width="441" alt="스크린샷 2024-10-16 오후 2 23 17" src="https://github.com/user-attachments/assets/6d72f405-b3f2-41d4-9ab8-db44797bde61">


## 구현사항
- [X] 화면기획과 같이 렌더링하고자 2차분류 검색 시에는 (앱에 들어가는 화면: http://localhost:3001/liquor/search/result?subKey=13와 같이 접근) searchParams에서 subKey가 있나 확인해서 있을 경우 필요한 부분만 렌더링 하도록했습니다. 일반 검색결과와는 달리 searchinput과 인기순/정확도순, 필터 버튼이 렌더링되지 않습니다.
- [X] LiquorCard가 화면의 width가 400px이하일 경우 안의 컨텐츠가 overflow되는 문제가 있어 수정했습니다.