### PR TITLE
[Feat] 전체카테고리 추가 & 앱으로돌아가기

### DIFF
--- a/app/liquor/category/result/page.tsx
+++ b/app/liquor/category/result/page.tsx
@@ -19,11 +19,7 @@ function CategoryParamsHandler({
   return <>{children(new URLSearchParams(searchParams.toString()))}</>;
 }
 
-function SearchInfoSection({
-  count,
-}: {
-  count: number;
-}) {
+function SearchInfoSection({ count }: { count: number }) {
   return (
     <section className="h-[44px] px-[20px]">
       <div className="flex items-center justify-between pt-3.5">
@@ -60,9 +56,12 @@ function LiquorCategoryContent({
 }: {
   searchParams: URLSearchParams;
 }) {
+  const query = searchParams.get("q");
+  const tag = !query || query === "전체" ? undefined : query;
+
   const { data, isLoading, error } = useLiquorSearch(
     {
-      tag: searchParams.get("q") || undefined,
+      tag,
       recordSize: 100,
     },
     searchParams.toString(),
@@ -86,7 +85,7 @@ function LiquorCategoryContent({
     <main className="flex min-h-screen flex-col pb-[10px]">
       <CategoryHeader tagValue={tagValue} />
       <CategoryFilter />
-      <SearchInfoSection count={isLoading ? 0 : liquors.length}/>
+      <SearchInfoSection count={isLoading ? 0 : liquors.length} />
       {isLoading ? (
         <section className="flex flex-col items-center justify-center gap-2.5 overflow-y-auto px-[20px]">
           <LoadingCard />
@@ -107,7 +106,9 @@ function LiquorCategoryResultPage() {
   return (
     <Suspense fallback>
       <CategoryParamsHandler>
-        {(searchParams) => <LiquorCategoryContent searchParams={searchParams} />}
+        {(searchParams) => (
+          <LiquorCategoryContent searchParams={searchParams} />
+        )}
       </CategoryParamsHandler>
     </Suspense>
   );

--- a/components/liquor/category/CategoryClassSection.tsx
+++ b/components/liquor/category/CategoryClassSection.tsx
@@ -1,6 +1,7 @@
 import Tag from "components/shared/Tag";
 import { useGetLiquorName } from "apis/tag/useGetLiquorName";
 import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 interface LiquorClassSectionProps {
   selected: string[];
@@ -16,7 +17,14 @@ function CategoryClassSection({
   const router = useRouter();
 
   const isValidLiquors = Array.isArray(liquors) && liquors.length > 0;
-  const queryClass = searchParams.get("q") || "전체"; // q가 없을 때 "전체"로 설정
+  const queryClass = searchParams.get("q");
+
+  // q 값이 없으면 q=전체로 리다이렉트
+  useEffect(() => {
+    if (!queryClass) {
+      router.push(`/liquor/category/result?q=전체`);
+    }
+  }, [queryClass, router]);
 
   // 태그 클릭 핸들러
   const handleTagClick = (name: string) => {

--- a/components/liquor/category/CategoryClassSection.tsx
+++ b/components/liquor/category/CategoryClassSection.tsx
@@ -16,7 +16,7 @@ function CategoryClassSection({
   const router = useRouter();
 
   const isValidLiquors = Array.isArray(liquors) && liquors.length > 0;
-  const queryClass = searchParams.get("q");
+  const queryClass = searchParams.get("q") || "전체"; // q가 없을 때 "전체"로 설정
 
   // 태그 클릭 핸들러
   const handleTagClick = (name: string) => {
@@ -27,6 +27,16 @@ function CategoryClassSection({
 
   return (
     <section className="flex max-w-full gap-2 overflow-x-scroll scrollbar-hide">
+      <Tag
+        tagId={99}
+        tagColor={
+          queryClass === "전체" || selected.includes("전체") ? "mint" : "gray"
+        }
+        selected={queryClass === "전체" || selected.includes("전체")}
+        onClick={() => handleTagClick("전체")}
+      >
+        전체
+      </Tag>
       {isValidLiquors &&
         liquors.map((liquor) => (
           <Tag

--- a/components/liquor/category/CategoryClassSection.tsx
+++ b/components/liquor/category/CategoryClassSection.tsx
@@ -26,14 +26,20 @@ function CategoryClassSection({
   };
 
   return (
-    <section className="flex gap-2 overflow-x-scroll max-w-full scrollbar-hide">
+    <section className="flex max-w-full gap-2 overflow-x-scroll scrollbar-hide">
       {isValidLiquors &&
         liquors.map((liquor) => (
           <Tag
             key={liquor.id}
             tagId={liquor.id}
-            tagColor={queryClass === liquor.name || selected.includes(liquor.name) ? "blue" : "gray"}
-            selected={queryClass === liquor.name || selected.includes(liquor.name)}
+            tagColor={
+              queryClass === liquor.name || selected.includes(liquor.name)
+                ? "mint"
+                : "gray"
+            }
+            selected={
+              queryClass === liquor.name || selected.includes(liquor.name)
+            }
             onClick={() => handleTagClick(liquor.name)}
           >
             {liquor.name}

--- a/components/liquor/category/CategoryHeader.tsx
+++ b/components/liquor/category/CategoryHeader.tsx
@@ -14,10 +14,10 @@ function CategoryHeader({ tagValue }: CategoryHeaderProps) {
   };
 
   return (
-    <div className="relative w-full pt-1 flex items-center px-2">
+    <div className="relative flex h-[48px] w-full items-center border-b px-2 pt-1">
       <HeadBackIcon onClick={handleBackHome} />
-      <div className="relative flex w-full items-center justify-center">
-        <div className="w-full py-2 text-center mr-8">{tagValue}</div>
+      <div className="border-b-1 relative flex w-full items-center justify-center">
+        <div className="mr-8 w-full py-2 text-center"></div>
       </div>
     </div>
   );

--- a/components/liquor/category/CategoryHeader.tsx
+++ b/components/liquor/category/CategoryHeader.tsx
@@ -4,18 +4,39 @@ import HeadBackIcon from "assets/icons/ico-head-back.svg";
 interface CategoryHeaderProps {
   tagValue: string;
 }
+// 앱으로 돌아가기
+const sendMessageToFlutter = () => {
+  console.log("Attempting to send message to Flutter...");
+
+  try {
+    // Android의 경우
+    if (window.AndroidBridge) {
+      console.log("Android bridge detected, sending message...");
+      window.AndroidBridge.goBack();
+      console.log("Message sent to Android successfully");
+    }
+    // iOS의 경우
+    else if (window.webkit && window.webkit.messageHandlers) {
+      console.log("iOS bridge detected, sending message...");
+      window.webkit.messageHandlers.goBack.postMessage("goBack");
+      console.log("Message sent to iOS successfully");
+    } else {
+      console.warn(
+        "No Flutter bridge detected. Are you running in a Flutter WebView?",
+      );
+    }
+  } catch (error) {
+    console.error("Error sending message to Flutter:", error);
+  }
+};
 
 // 카테고리 헤더 컴포넌트
 function CategoryHeader({ tagValue }: CategoryHeaderProps) {
   const router = useRouter();
 
-  const handleBackHome = () => {
-    router.push(`/`);
-  };
-
   return (
     <div className="relative flex h-[48px] w-full items-center border-b px-2 pt-1">
-      <HeadBackIcon onClick={handleBackHome} />
+      <HeadBackIcon onClick={sendMessageToFlutter} />
       <div className="border-b-1 relative flex w-full items-center justify-center">
         <div className="mr-8 w-full py-2 text-center"></div>
       </div>

--- a/components/shared/Tag/index.tsx
+++ b/components/shared/Tag/index.tsx
@@ -8,6 +8,9 @@ function Tag({ children, tagColor, tagId, selected, onClick }: TagProps) {
   if (selected) {
     tagStyle =
       "bg-suldak-mint-50 border border-suldak-mint-500 text-suldak-mint-500 text-[14px] font-medium";
+    if (tagColor == "mint") {
+      tagStyle = "bg-suldak-mint-500 text-white text-[14px]";
+    }
   } else {
     switch (tagColor) {
       case "blue":

--- a/components/shared/Tag/types.d.ts
+++ b/components/shared/Tag/types.d.ts
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef } from "react";
 
-type TagColor = "gray" | "blue";
+type TagColor = "gray" | "blue" | "mint";
 
 /**
  * 태그 인터페이스


### PR DESCRIPTION
## 스크린샷
- 변경전
<img width="200" alt="스크린샷 2024-11-12 오후 7 21 42" src="https://github.com/user-attachments/assets/32ed14d1-b191-4f6e-8b09-961e19fc9b1f">

- 변경후
<img width="200" alt="스크린샷 2024-11-12 오후 7 51 34" src="https://github.com/user-attachments/assets/41b5c0a8-604f-4e96-8b07-78d20b9fba3c">

- 앱으로 돌아가기 버튼 클릭 시 : 현재는 연결된 플러터 앱이 없다는 로그문구가 뜹니다.
<img width="450" alt="스크린샷 2024-11-12 오후 7 51 47" src="https://github.com/user-attachments/assets/e1221ce0-c9f5-4c2d-80a1-4805020996ea">


## 구현사항
- [x] 앱으로 돌아가기 버튼
- [x] 카테고리 상에 전체 카테고리가 없어 추가했습니다. 만약 "/liquor/category/result"의 url로 접근할 경우 "/liquor/category/result?q=전체"로 리다이렉트 됩니다.
- [x] Tag에 mint를 추가하고, 헤더 상에서 제목을 삭제하고, 구분선을 추가해 피그마 시안처럼 스타일을 수정했습니다. 
 