### PR TITLE
[Fix] RecommendKeyword, RankingKeyword 데이터가 없을경우 예외처리

### DIFF
--- a/components/liquor/search/RecommendKeyword.tsx
+++ b/components/liquor/search/RecommendKeyword.tsx
@@ -9,6 +9,14 @@ function RecommendKeyword() {
   const router = useRouter();
   const { data: recommendKeywords } = useGetRecommendKeyword();
 
+  // 데이터가 없을 경우 처리
+  if (
+    !recommendKeywords ||
+    !Array.isArray(recommendKeywords) ||
+    recommendKeywords.length === 0
+  ) {
+    return <></>;
+  }
   const handleClick = (
     event: React.MouseEvent<HTMLSpanElement>,
     text: string,

--- a/components/liquor/search/ranking/RankingKeyword.tsx
+++ b/components/liquor/search/ranking/RankingKeyword.tsx
@@ -4,7 +4,14 @@ import RankingKeywordList from "./RankingKeywordList";
 
 function RankingKeyword() {
   const { data: rankingKeywords } = useGetRankingKeyword();
-
+  // 데이터가 없을 경우 처리
+  if (
+    !rankingKeywords ||
+    !Array.isArray(rankingKeywords) ||
+    rankingKeywords.length === 0
+  ) {
+    return <></>;
+  }
   return (
     <div className="flex items-center gap-14">
       <RankingKeywordList


### PR DESCRIPTION
## 스크린샷
<img width="1440" alt="스크린샷 2025-04-05 오후 7 06 02" src="https://github.com/user-attachments/assets/285979d5-b7e8-4773-a433-b655ec11447f" />

## 변경사항
clientside execption이 해결되지 않아 "TypeError: Cannot read properties of undefined (reading 'map')"에 대해 더 생각해보니 map을 사용하는 컴포넌트에 문제가 있을 것 같아 수정했습니다. 지금까진 데이터가 있는 환경이라 문제가 없었는데 서버 이전 / DB 초기화로 추천검색어 데이터가 없어서 생긴 문제라 생각했습니다.