### PR TITLE
[Fix] 웹뷰 토큰 전달 방식을 HTTP헤더 방식으로 변경

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,56 +40,23 @@ export default function RootLayout({
                 if (cookieToken) {
                   console.log('Found token in cookie, saving to localStorage');
                   localStorage.setItem('authToken', cookieToken);
-                  return true;
+                  return true; // 쿠키에서 토큰을 찾으면 로컬 스토리지에 저장하고 true 반환
                 }
                 
-                // 2. 로컬 스토리지 확인
+                // 2. 로컬 스토리지 확인 (쿠키에 없으면 로컬 스토리지 확인)
                 const storedToken = localStorage.getItem('authToken');
                 if (storedToken) {
-                  console.log('Using stored token');
-                  return true;
+                  console.log('Using stored token from localStorage');
+                  return true; // 로컬 스토리지에 토큰이 있으면 true 반환
                 }
                 
-                return false;
+                return false; // 쿠키와 로컬 스토리지 모두에 토큰이 없음
               };
               
-              // 토큰이 없으면 FlutterBridge에 요청
+              // 토큰 확인 실행 (FlutterBridge 요청 부분 제거됨)
               if (!checkForToken()) {
-                let attempts = 0;
-                const maxAttempts = 5;
-                
-                const requestToken = function() {
-                  if (attempts >= maxAttempts) return;
-                  
-                  attempts++;
-                  console.log('Requesting token from Flutter, attempt ' + attempts);
-                  
-                  if (window.FlutterBridge) {
-                    try {
-                      window.FlutterBridge.postMessage('requestToken');
-                    } catch (e) {
-                      console.error('Error requesting token:', e);
-                    }
-                  }
-                };
-                
-                // 즉시 한번 요청
-                setTimeout(requestToken, 500);
-                
-                // 1초마다 재시도 (최대 5회)
-                const interval = setInterval(() => {
-                  // 토큰이 이미 설정되었으면 중단
-                  if (checkForToken()) {
-                    clearInterval(interval);
-                    return;
-                  }
-                  
-                  requestToken();
-                  
-                  if (attempts >= maxAttempts) {
-                    clearInterval(interval);
-                  }
-                }, 1000);
+                console.log('No token found in cookies or localStorage. Waiting for potential header injection or using fallback.');
+                // 필요한 경우 여기에 환경 변수 토큰 사용 등의 대체 로직 추가 가능
               }
             } catch (e) {
               console.error('Error in token initialization script:', e);

--- a/app/liquor/hooks/useFlutterToken.ts
+++ b/app/liquor/hooks/useFlutterToken.ts
@@ -1,33 +1,29 @@
 import { useEffect, useState } from "react";
-import {
-  receiveTokenFromFlutter,
-  requestTokenFromFlutter,
-} from "../utils/flutterBridge";
 import { getToken } from "../utils/tokenStore";
 
+/**
+ * 토큰 초기화 상태를 관리하는 훅.
+ * 헤더 주입 방식으로 변경됨에 따라 로직 단순화.
+ */
 export const useFlutterToken = () => {
   const [isTokenInitialized, setIsTokenInitialized] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    // 플러터에서 토큰을 받기 위한 수신자 설정 (항상 실행)
-    receiveTokenFromFlutter();
+    // 컴포넌트 마운트 시 토큰 존재 여부와 관계없이 초기화 상태로 간주
+    // 실제 토큰 사용은 getToken()을 통해 각 컴포넌트/API 호출 시점에 수행
+    setIsTokenInitialized(true);
 
-    // 토큰이 이미 있는지 확인
-    const existingToken = getToken();
-
-    // 토큰이 없고 아직 초기화되지 않았을 때만 요청
-    if (!existingToken && !isTokenInitialized) {
-      // 약간의 지연 후 토큰 요청 (페이지 로드 완료 후)
-      setTimeout(() => {
-        requestTokenFromFlutter();
-        setIsTokenInitialized(true);
-      }, 300);
-    } else {
-      setIsTokenInitialized(true);
-    }
-  }, [isTokenInitialized]);
+    // flutterBridge 관련 로직 제거
+    // receiveTokenFromFlutter();
+    // const existingToken = getToken();
+    // if (!existingToken) {
+    //   setTimeout(() => {
+    //     requestTokenFromFlutter();
+    //   }, 300);
+    // }
+  }, []); // 최초 마운트 시에만 실행하도록 의존성 배열 비움
 
   return { isTokenInitialized };
 };

--- a/app/liquor/search/page.tsx
+++ b/app/liquor/search/page.tsx
@@ -4,15 +4,13 @@ import { Suspense, useEffect, useState } from "react";
 import RecentSearchSection from "components/liquor/search/section/RecentSearchSection";
 import RecommendedSearchSection from "components/liquor/search/section/RecommendSearchSection";
 import SearchRankingSection from "components/liquor/search/section/SearchRankingSection";
-import { useFlutterToken } from "../hooks/useFlutterToken";
 import { getToken } from "../utils/tokenStore";
 
 /** 술 검색 페이지 */
 function LiquorSearchPage() {
   const [hasToken, setHasToken] = useState<boolean>(false);
-  const { isTokenInitialized } = useFlutterToken();
 
-  // 토큰 상태 체크 및 업데이트 이벤트 리스너
+  // 토큰 상태 체크
   useEffect(() => {
     if (typeof window === "undefined") return;
 
@@ -20,22 +18,29 @@ function LiquorSearchPage() {
     const checkToken = () => {
       const token = getToken();
       setHasToken(!!token);
+      // 토큰 유무에 따라 필요한 로직 수행 (예: API 호출)
+      if (token) {
+        console.log("Token found, proceeding with authenticated actions.");
+      } else {
+        console.log(
+          "No token found, proceeding with public actions or using fallback.",
+        );
+        // 필요한 경우 환경 변수 토큰 사용 로직 호출 등
+      }
     };
 
     checkToken();
 
-    // 토큰 업데이트 이벤트 리스너
-    const handleTokenUpdate = () => {
-      console.log("Token updated event received");
-      checkToken();
-    };
-
-    window.addEventListener("tokenUpdated", handleTokenUpdate);
-
-    return () => {
-      window.removeEventListener("tokenUpdated", handleTokenUpdate);
-    };
-  }, [isTokenInitialized]);
+    // tokenUpdated 이벤트 리스너 제거
+    // const handleTokenUpdate = () => {
+    //   console.log("Token updated event received");
+    //   checkToken();
+    // };
+    // window.addEventListener("tokenUpdated", handleTokenUpdate);
+    // return () => {
+    //   window.removeEventListener("tokenUpdated", handleTokenUpdate);
+    // };
+  }, []); // 의존성 배열 비움 (최초 마운트 시에만 실행)
 
   return (
     <>

--- a/app/liquor/utils/flutterBridge.ts
+++ b/app/liquor/utils/flutterBridge.ts
@@ -22,7 +22,8 @@ const sendMessageToFlutter = () => {
   }
 };
 
-// 플러터로부터 토큰을 받는 함수
+// 플러터로부터 토큰을 받는 함수 (제거됨)
+/*
 const receiveTokenFromFlutter = () => {
   // window 객체 존재 여부 확인
   if (typeof window === "undefined") return;
@@ -52,8 +53,10 @@ const receiveTokenFromFlutter = () => {
     console.error("Error setting up token receiver:", error);
   }
 };
+*/
 
-// 플러터에 토큰 요청
+// 플러터에 토큰 요청 (제거됨)
+/*
 const requestTokenFromFlutter = () => {
   // window 객체 존재 여부 확인
   if (typeof window === "undefined") return;
@@ -71,9 +74,10 @@ const requestTokenFromFlutter = () => {
     console.error("Error requesting token from Flutter:", error);
   }
 };
+*/
 
 export {
   sendMessageToFlutter,
-  receiveTokenFromFlutter,
-  requestTokenFromFlutter,
+  // receiveTokenFromFlutter, // 제거됨
+  // requestTokenFromFlutter, // 제거됨
 };


### PR DESCRIPTION
Flutter 앱과의 사용자 토큰 전달 방식을 기존 JavaScript Bridge 방식에서 HTTP 헤더(`Authorization`)를 이용하는 방식으로 변경합니다.

## 변경 사항:
- [X] 미들웨어(`middleware.ts`): 요청 헤더에서 `Authorization` 토큰을 읽어 `authToken` 쿠키를 설정
- [X] `layout.tsx`: 초기화 스크립트가 `authToken` 쿠키를 읽어 로컬 스토리지에 저장하도록 수정하고, 불필요해진 Bridge 관련 토큰 요청 로직을 제거
- [X] `useFlutterToken.ts`: Bridge 관련 로직을 제거하고 훅을 단순화
- [X] `search/page.tsx`: Bridge 관련 의존성(`useFlutterToken`, `tokenUpdated` 이벤트)을 제거하고, `getToken`을 직접 호출하여 토큰 상태를 확인하도록 수정
