### PR TITLE
[Fix] 칵테일 필요재료가 안보이는 문제 해결

### DIFF
--- a/components/liquor/detail/DetailMaterial.tsx
+++ b/components/liquor/detail/DetailMaterial.tsx
@@ -9,7 +9,7 @@ function DetailMaterial({ material }: DetailMaterialProps) {
   return (
     <div className="pb-50px">
       <div className="flex items-center gap-1.5 pb-3">
-        <span className="text-lg font-bold text-suldak-gray-900">
+        <span className="text-[16px] font-bold text-suldak-gray-900">
           필요 재료
         </span>
       </div>

--- a/components/liquor/detail/DetailMaterial.tsx
+++ b/components/liquor/detail/DetailMaterial.tsx
@@ -1,30 +1,26 @@
-import { LiquorMaterial as LiquorMaterialType } from "models/liquor";
+import Tag from "components/shared/Tag";
 
-interface DetailSnackProps {
-  material: LiquorMaterialType[];
+interface DetailMaterialProps {
+  material: string[];
 }
 
-/** 술 재료 컴포넌트 */
-function DetailMaterial({ material }: DetailSnackProps) {
-  if (!material || material.length === 0) {
-    return null;
-  }
-
+/** 술 재료 */
+function DetailMaterial({ material }: DetailMaterialProps) {
   return (
-    <section className="pb-50px">
-      <div className="flex items-center gap-1.5">
+    <div className="pb-50px">
+      <div className="flex items-center gap-1.5 pb-3">
         <span className="text-lg font-bold text-suldak-gray-900">
           필요 재료
         </span>
       </div>
-      <div className="mt-5 flex flex-wrap gap-3"> 
-        {material.map((mat, index) => (
-          <span key={index} className="inline-flex items-center justify-center border border-suldak-gray-500 rounded-30px px-4 py-2.5 text-suldak-gray-900">
-            {mat.name}
-          </span>
+      <div className="flex flex-wrap gap-2">
+        {material.map((item, index) => (
+          <Tag key={item} tagId={index} tagColor="gray">
+            {item}
+          </Tag>
         ))}
       </div>
-    </section>
+    </div>
   );
 }
 

--- a/components/liquor/detail/DetailRecipe.tsx
+++ b/components/liquor/detail/DetailRecipe.tsx
@@ -15,9 +15,9 @@ function DetailRecipe({ recipe, material }: DetailRecipeProps) {
 
   return (
     <section className="px-5 pb-50px pt-50px">
-      <div className="flex items-center gap-1.5 pb-50px">
+      <div className="flex items-center gap-1.5 pb-[20px]">
         <RecipeIcon />
-        <span className="text-lg font-bold text-suldak-gray-900">
+        <span className="font-bold text-[18p] text-suldak-gray-900">
           직접 만들어볼까요?
         </span>
       </div>
@@ -25,7 +25,9 @@ function DetailRecipe({ recipe, material }: DetailRecipeProps) {
         <DetailMaterial material={material} />
       )}
       <div className="flex items-center gap-2">
-        <span className="text-lg font-bold text-suldak-gray-900">레시피</span>
+        <span className="text-[16px] font-bold text-suldak-gray-900">
+          레시피
+        </span>
         <span className="text-sm text-suldak-red-500">*1oz는 약 30ml에요</span>
       </div>
       <div className="mt-5 flex flex-col">

--- a/components/liquor/detail/DetailRecipe.tsx
+++ b/components/liquor/detail/DetailRecipe.tsx
@@ -1,10 +1,10 @@
 import RecipeIcon from "assets/icons/ico-liquor-recipe.svg";
 import DetailMaterial from "./DetailMaterial";
-import { LiquorMaterial as LiquorMaterialType } from "models/liquor";
+import { LiquorMaterial } from "models/liquor";
 
 interface DetailRecipeProps {
   recipe: string[];
-  material: LiquorMaterialType[];
+  material: string[];
 }
 
 /** 술 레시피 컴포넌트 */
@@ -21,23 +21,25 @@ function DetailRecipe({ recipe, material }: DetailRecipeProps) {
           직접 만들어볼까요?
         </span>
       </div>
-      {material && <DetailMaterial material={material} />}
+      {material && material.length > 0 && (
+        <DetailMaterial material={material} />
+      )}
       <div className="flex items-center gap-2">
         <span className="text-lg font-bold text-suldak-gray-900">레시피</span>
-        <span className="text-suldak-red-500 text-sm">*1oz는 약 30ml에요</span>
+        <span className="text-sm text-suldak-red-500">*1oz는 약 30ml에요</span>
       </div>
       <div className="mt-5 flex flex-col">
         {recipe.map((rec, index) => (
-          <div className="flex items-start gap-4 w-full h-auto" key={index}>
-            <div className="relative flex-shrink-0 flex flex-col items-center">
-              <div className="rounded-full w-8 h-8 bg-suldak-gray-300 text-suldak-gray-600 flex items-center justify-center">
+          <div className="flex h-auto w-full items-start gap-4" key={index}>
+            <div className="relative flex flex-shrink-0 flex-col items-center">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-suldak-gray-300 text-suldak-gray-600">
                 {index + 1}
               </div>
-              {index < recipe.length -1 && (
-                <div className="w-px h-12 bg-suldak-gray-300" />
+              {index < recipe.length - 1 && (
+                <div className="h-12 w-px bg-suldak-gray-300" />
               )}
             </div>
-            <span className="text-gray-500 flex-grow">{rec}</span>
+            <span className="flex-grow text-gray-500">{rec}</span>
           </div>
         ))}
       </div>

--- a/components/liquor/detail/LiquorDetail.tsx
+++ b/components/liquor/detail/LiquorDetail.tsx
@@ -14,6 +14,9 @@ import { sendMessageToFlutter } from "app/liquor/utils/flutterBridge";
 /** 술 상세 컴포넌트 */
 function LiquorDetail({ id }: { id: number }) {
   const { data: liquor } = useGetLiquorDetail(id);
+  console.log("Fetched Liquor Data:", liquor);
+  console.log("Liquor Material List:", liquor?.liquorMaterialList);
+  console.log("Liquor Recipe:", liquor?.liquorRecipe);
   const router = useRouter();
   const searchParams = useSearchParams();
   const [touchStartX, setTouchStartX] = useState<number | null>(null);
@@ -95,7 +98,7 @@ function LiquorDetail({ id }: { id: number }) {
       <div className="h-2.5 w-full bg-suldak-gray-200" />
       <DetailRecipe
         recipe={liquor.liquorRecipe}
-        material={liquor.liquorMaterialDtos}
+        material={liquor.liquorMaterialList}
       />
     </>
   );

--- a/components/shared/Tag/index.tsx
+++ b/components/shared/Tag/index.tsx
@@ -21,6 +21,10 @@ function Tag({ children, tagColor, tagId, selected, onClick }: TagProps) {
         tagStyle =
           "bg-white text-suldak-gray-900 border-suldak-gray-400 text-[14px] border";
         break;
+      case "mint":
+        tagStyle =
+          "bg-suldak-mint-50 text-suldak-mint-500 text-[14px] font-medium";
+        break;
       default:
         tagStyle =
           "bg-white text-suldak-gray-900 border-suldak-gray-400 text-[14px] border";
@@ -33,7 +37,6 @@ function Tag({ children, tagColor, tagId, selected, onClick }: TagProps) {
       onClick(event, children as string);
     }
   };
-
 
   return (
     <span

--- a/models/liquor.ts
+++ b/models/liquor.ts
@@ -15,7 +15,7 @@ export interface Liquor {
 
   liquorDetailDto: unknown;
 
-  liquorMaterialDtos: LiquorMaterial[];
+  liquorMaterialList: string[]; // 술 재료 목록
   // liquorMaterialDtos: string[]; 백오피스 수정 후 문자열로 바뀔 예정입니다.
 
   liquorNameDto: {


### PR DESCRIPTION
규리님께서 칵테일 필요재료가 보이지 않는 문제가 있다고 알려주셔서 해결했습니다.
## 스크린샷

<img width="397" alt="스크린샷 2025-05-06 오전 11 57 11" src="https://github.com/user-attachments/assets/ec81bf59-7164-440b-b710-f123d86d24f6" />

## 변경사항
- [X] liquorMaterialList에 맞춰 필드명과 타입을 일치시킴
- [X] 필요재료 렌더링 시 Tag 사용 
- [X] 여백과 폰트 사이즈 변경