### PR TITLE
[Style] 레시피 섹션 스타일링 수정

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,29 +3,29 @@
 @tailwind utilities;
 
 @font-face {
-  font-family: 'Pretendard';
+  font-family: "Pretendard";
   font-style: normal;
   font-weight: 400;
-  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')
-    format('woff');
+  src: url("https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
+    format("woff");
 }
 
 @font-face {
-  font-family: 'GMarket';
+  font-family: "GMarket";
   font-style: normal;
   font-weight: 400;
-  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansMedium.woff')
-    format('woff');
+  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansMedium.woff")
+    format("woff");
 }
 
 @font-face {
-  font-family: 'Pretendard';
+  font-family: "Pretendard";
   font-style: normal;
   font-weight: 700;
-  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff')
-    format('woff');
+  src: url("https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff")
+    format("woff");
 }
 
 body {
-  font-family: 'Pretendard', sans-serif;
+  font-family: "Pretendard", sans-serif;
 }

--- a/components/liquor/detail/DetailMaterial.tsx
+++ b/components/liquor/detail/DetailMaterial.tsx
@@ -7,13 +7,13 @@ interface DetailMaterialProps {
 /** 술 재료 */
 function DetailMaterial({ material }: DetailMaterialProps) {
   return (
-    <div className="pb-50px">
+    <div className="pb-[50px]">
       <div className="flex items-center gap-1.5 pb-3">
-        <span className="text-[16px] font-bold text-suldak-gray-900">
+        <span className="text-[16px] font-semibold text-suldak-gray-900">
           필요 재료
         </span>
       </div>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-[8px]">
         {material.map((item, index) => (
           <Tag key={item} tagId={index} tagColor="gray">
             {item}

--- a/components/liquor/detail/DetailRecipe.tsx
+++ b/components/liquor/detail/DetailRecipe.tsx
@@ -14,10 +14,10 @@ function DetailRecipe({ recipe, material }: DetailRecipeProps) {
   }
 
   return (
-    <section className="px-5 pb-50px pt-50px">
-      <div className="flex items-center gap-1.5 pb-[20px]">
+    <section className="px-5 mb-[50px] mt-[50px]">
+      <div className="flex items-center gap-[2px] pb-[20px]">
         <RecipeIcon />
-        <span className="font-bold text-[18p] text-suldak-gray-900">
+        <span className="text-[18px] font-bold text-suldak-gray-900">
           직접 만들어볼까요?
         </span>
       </div>
@@ -25,20 +25,23 @@ function DetailRecipe({ recipe, material }: DetailRecipeProps) {
         <DetailMaterial material={material} />
       )}
       <div className="flex items-center gap-2">
-        <span className="text-[16px] font-bold text-suldak-gray-900">
+        <span className="text-[16px] font-semibold text-suldak-gray-900">
           레시피
         </span>
         <span className="text-sm text-suldak-red-500">*1oz는 약 30ml에요</span>
       </div>
-      <div className="mt-5 flex flex-col">
+      <div className="mt-[20px] flex flex-col">
         {recipe.map((rec, index) => (
-          <div className="flex h-auto w-full items-start gap-4" key={index}>
+          <div
+            className="flex h-auto w-full items-start gap-x-[10px]"
+            key={index}
+          >
             <div className="relative flex flex-shrink-0 flex-col items-center">
-              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-suldak-gray-300 text-suldak-gray-600">
+              <div className="flex h-8 w-8 items-center justify-center gap-y-[9px] rounded-full bg-suldak-gray-300 text-suldak-gray-600">
                 {index + 1}
               </div>
               {index < recipe.length - 1 && (
-                <div className="h-12 w-px bg-suldak-gray-300" />
+                <div className="h-12 bg-suldak-gray-300" />
               )}
             </div>
             <span className="flex-grow text-gray-500">{rec}</span>

--- a/components/liquor/detail/DetailRecipe.tsx
+++ b/components/liquor/detail/DetailRecipe.tsx
@@ -14,7 +14,7 @@ function DetailRecipe({ recipe, material }: DetailRecipeProps) {
   }
 
   return (
-    <section className="mb-[50px] mt-[50px] px-5">
+    <section className="mb-[64px] mt-[50px] px-5">
       <div className="flex items-center gap-[2px] pb-[20px]">
         <RecipeIcon />
         <span className="text-[18px] font-bold text-suldak-gray-900">
@@ -32,19 +32,16 @@ function DetailRecipe({ recipe, material }: DetailRecipeProps) {
       </div>
       <div className="mt-[20px] flex flex-col">
         {recipe.map((rec, index) => (
-          <div
-            className="my-[9px] flex h-auto w-full items-start gap-x-[10px]"
-            key={index}
-          >
-            <div className="relative flex flex-shrink-0 flex-col items-start">
+          <div className="flex w-full items-start gap-x-[10px]" key={index}>
+            <div className="relative flex flex-shrink-0 flex-col items-center">
               <div className="flex h-[21px] w-[21px] items-center justify-center rounded-full bg-suldak-gray-300 text-suldak-gray-600">
                 {index + 1}
               </div>
               {index < recipe.length - 1 && (
-                <div className="h-12 bg-suldak-gray-300" />
+                <div className="min-h-[30px] w-[2px] flex-1 bg-suldak-gray-300" />
               )}
             </div>
-            <span className="flex-grow text-base leading-normal text-gray-500">
+            <span className="text-normal flex-grow text-[14px] text-base leading-normal text-gray-500">
               {rec}
             </span>
           </div>

--- a/components/liquor/detail/DetailRecipe.tsx
+++ b/components/liquor/detail/DetailRecipe.tsx
@@ -14,7 +14,7 @@ function DetailRecipe({ recipe, material }: DetailRecipeProps) {
   }
 
   return (
-    <section className="px-5 mb-[50px] mt-[50px]">
+    <section className="mb-[50px] mt-[50px] px-5">
       <div className="flex items-center gap-[2px] pb-[20px]">
         <RecipeIcon />
         <span className="text-[18px] font-bold text-suldak-gray-900">
@@ -33,18 +33,20 @@ function DetailRecipe({ recipe, material }: DetailRecipeProps) {
       <div className="mt-[20px] flex flex-col">
         {recipe.map((rec, index) => (
           <div
-            className="flex h-auto w-full items-start gap-x-[10px]"
+            className="my-[9px] flex h-auto w-full items-start gap-x-[10px]"
             key={index}
           >
-            <div className="relative flex flex-shrink-0 flex-col items-center">
-              <div className="flex h-8 w-8 items-center justify-center gap-y-[9px] rounded-full bg-suldak-gray-300 text-suldak-gray-600">
+            <div className="relative flex flex-shrink-0 flex-col items-start">
+              <div className="flex h-[21px] w-[21px] items-center justify-center rounded-full bg-suldak-gray-300 text-suldak-gray-600">
                 {index + 1}
               </div>
               {index < recipe.length - 1 && (
                 <div className="h-12 bg-suldak-gray-300" />
               )}
             </div>
-            <span className="flex-grow text-gray-500">{rec}</span>
+            <span className="flex-grow text-base leading-normal text-gray-500">
+              {rec}
+            </span>
           </div>
         ))}
       </div>

--- a/components/liquor/detail/DetailSnack.tsx
+++ b/components/liquor/detail/DetailSnack.tsx
@@ -13,13 +13,17 @@ function DetailSnack({ snacks }: DetailSnackProps) {
     <section className="px-5 pb-50px pt-50px">
       <div className="flex items-center gap-1.5">
         <SnackIcon />
-        <span className="text-lg font-bold text-suldak-gray-900">
+        <span className="text-[18px] font-bold text-suldak-gray-900">
           이런 안주와 어울려요
         </span>
       </div>
       <div className="mt-5 flex gap-3">
         {snacks.map((snack) => (
-          <LiquorSnack key={snack.id} name={snack.name} imgUrl={snack.fileBaseNm} />
+          <LiquorSnack
+            key={snack.id}
+            name={snack.name}
+            imgUrl={snack.fileBaseNm}
+          />
         ))}
       </div>
     </section>

--- a/components/liquor/search/ranking/RankingKeyword.tsx
+++ b/components/liquor/search/ranking/RankingKeyword.tsx
@@ -5,16 +5,26 @@ import RankingKeywordList from "./RankingKeywordList";
 function RankingKeyword() {
   const { data: rankingKeywords = [] } = useGetRankingKeyword();
 
+  // 왼쪽(1~5), 오른쪽(6~10) 분리
+  const leftKeywords = rankingKeywords.slice(0, 5);
+  const rightKeywords = rankingKeywords.slice(5, 10);
+
+  // 오른쪽 컬럼이 5개 미만일 때 placeholder 추가
+  const rightColumnLength = rightKeywords.length;
+  const rightPlaceholders = Array(5 - rightColumnLength).fill(null);
+
   return (
-    <div className="flex items-center gap-14">
-      <RankingKeywordList
-        keywords={rankingKeywords.slice(0, 5)}
-        startIndex={0}
-      />
-      <RankingKeywordList
-        keywords={rankingKeywords.slice(5, 10)}
-        startIndex={5}
-      />
+    <div className="flex items-start gap-14">
+      <RankingKeywordList keywords={leftKeywords} startIndex={0} />
+      <RankingKeywordList keywords={rightKeywords} startIndex={5} />
+      {/* 오른쪽 컬럼이 5개 미만이면 placeholder로 공간 확보 */}
+      {rightColumnLength < 5 && (
+        <div className="pointer-events-none invisible absolute flex flex-col gap-y-[13px]">
+          {rightPlaceholders.map((_, idx) => (
+            <div key={idx} className="h-[24px]" />
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 스크린샷
<img width="365" alt="스크린샷 2025-05-15 오후 8 21 54" src="https://github.com/user-attachments/assets/d95cea5c-b1bc-48d3-8f54-85b25be5d5cc" />


## 변경사항
- [X] QA 시트 레시피 수정요청을 반영하였습니다.

<img width="500" alt="스크린샷 2025-05-15 오후 7 27 26" src="https://github.com/user-attachments/assets/ce01d960-39c1-48b9-8aa8-05fe5c1cc6eb" />

- [X] liquor/search 페이지에서 검색 키워드 랭킹 키워드가 6개 이상 10개 미만일 경우 6번이 1번과 같은 높이에 정렬되지 않아 이 부분 수정했습니다.