### PR TITLE
[Fix] LiquorDetail api 중복 호출 해결

### DIFF
--- a/apis/liquor/useGetLiquorDetail.ts
+++ b/apis/liquor/useGetLiquorDetail.ts
@@ -3,15 +3,56 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { ResponseType } from "apis/api";
 import { Liquor } from "models/liquor";
 
+// 서버 컴포넌트용 fetch 함수
+export async function fetchLiquorDetail(
+  id: number,
+): Promise<ResponseType<Liquor>> {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3001";
+  const url = `${baseUrl}/api/liquor/${id}`;
+  const token = process.env.NEXT_PUBLIC_TOKEN;
+
+  console.log("[Server] 🔄 Fetching liquor detail - ID:", id);
+  console.log("[Server] 🌐 URL:", url);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: token || "",
+        "Content-Type": "application/json",
+      },
+    });
+
+    console.log("[Server] ✨ Response status:", response.status);
+
+    if (!response.ok) {
+      console.error("[Server] ❌ Response not OK:", {
+        status: response.status,
+        statusText: response.statusText,
+        url: response.url,
+      });
+      throw new Error(`Failed to fetch liquor detail: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log("[Server] ✅ Data fetched successfully");
+    return data;
+  } catch (error) {
+    console.error("[Server] 🚨 Fetch error:", error);
+    throw error;
+  }
+}
+
+// 클라이언트 컴포넌트용 함수
 const getLiquorDetail = async (id: number): Promise<ResponseType<Liquor>> => {
   try {
+    console.log("[Client] 🔄 Fetching liquor detail - ID:", id);
     const { data } = await axiosInstance.get<ResponseType<Liquor>>(
       `/api/liquor/${id}`,
     );
-
+    console.log("[Client] ✅ Data fetched successfully");
     return data;
   } catch (error) {
-    console.error("Error fetching liquor detail:", error);
+    console.error("[Client] 🚨 Error fetching liquor detail:", error);
     throw error;
   }
 };

--- a/app/liquor/detail/[id]/page.tsx
+++ b/app/liquor/detail/[id]/page.tsx
@@ -1,19 +1,39 @@
-"use client";
-
-import { Suspense } from "react";
-import { useParams } from "next/navigation";
 import LiquorDetail from "components/liquor/detail/LiquorDetail";
+import { fetchLiquorDetail } from "apis/liquor/useGetLiquorDetail";
+import { notFound } from "next/navigation";
 
-/** 술 상세 페이지 */
-function LiquorDetailPage() {
-  const { id } = useParams<{ id: string }>();
-  return (
-    <div>
-      <Suspense>
-        <LiquorDetail id={parseInt(id)} />
-      </Suspense>
-    </div>
-  );
+export const revalidate = 3600; // 1시간마다 재검증
+
+interface Props {
+  params: {
+    id: string;
+  };
 }
 
-export default LiquorDetailPage;
+export default async function LiquorDetailPage({ params }: Props) {
+  console.log("[Page] 🎯 Rendering detail page for ID:", params.id);
+
+  if (!params.id || isNaN(parseInt(params.id))) {
+    console.error("[Page] ❌ Invalid ID parameter:", params.id);
+    notFound();
+  }
+
+  try {
+    const response = await fetchLiquorDetail(parseInt(params.id));
+    console.log("[Page] ✅ Page rendered successfully");
+
+    if (!response || !response.data) {
+      console.error("[Page] ❌ No data in response for ID:", params.id);
+      notFound();
+    }
+
+    return (
+      <div>
+        <LiquorDetail liquorData={response.data} />
+      </div>
+    );
+  } catch (error) {
+    console.error("[Page] 🚨 Error in page render:", error);
+    throw error;
+  }
+}

--- a/components/liquor/detail/DetailImage.tsx
+++ b/components/liquor/detail/DetailImage.tsx
@@ -12,9 +12,20 @@ function DetailImage({ name = "술", imgUrl }: DetailImageProps) {
   // DefaultImg를 import한 경우, 해당 이미지의 실제 경로를 가져와야 합니다
   const defaultImgSrc = DefaultImg?.src || DefaultImg;
 
-  // imgUrl이 falsy(undefined, null, empty string)인 경우 defaultImgSrc 사용
-  const imageSource =
-    imgUrl && imgUrl.trim() ? `${BASE_URL}${imgUrl}` : defaultImgSrc;
+  // 유효한 이미지 URL인지 검증
+  const isValidImageUrl = (url?: string): boolean => {
+    if (!url) return false;
+    if (url === "null" || url.includes("null")) return false;
+    if (!url.trim()) return false;
+    return true;
+  };
+
+  // 이미지 소스 결정
+  const imageSource = isValidImageUrl(imgUrl)
+    ? `${BASE_URL}${imgUrl}`
+    : defaultImgSrc;
+
+  console.log("[Image] 🖼 Using image source:", imageSource);
 
   return (
     <section className="flex">
@@ -24,6 +35,8 @@ function DetailImage({ name = "술", imgUrl }: DetailImageProps) {
         alt={`${name} 사진`}
         height={400}
         width={500}
+        priority // 이미지를 우선적으로 로드
+        unoptimized={isValidImageUrl(imgUrl)} // 외부 이미지는 Next.js 최적화를 건너뜀
       />
     </section>
   );

--- a/components/liquor/detail/DetailMaterial.tsx
+++ b/components/liquor/detail/DetailMaterial.tsx
@@ -15,7 +15,7 @@ function DetailMaterial({ material }: DetailMaterialProps) {
       </div>
       <div className="flex flex-wrap gap-[8px]">
         {material.map((item, index) => (
-          <Tag key={item} tagId={index} tagColor="gray">
+          <Tag key={`${item}-${index}`} tagId={index} tagColor="gray">
             {item}
           </Tag>
         ))}

--- a/components/liquor/detail/LiquorDetail.tsx
+++ b/components/liquor/detail/LiquorDetail.tsx
@@ -1,33 +1,21 @@
 "use client";
 
-import { useGetLiquorDetail } from "apis/liquor/useGetLiquorDetail";
 import DetailImage from "./DetailImage";
 import DetailInfo from "./DetailInfo";
 import DetailSnack from "./DetailSnack";
 import DetailRecipe from "./DetailRecipe";
 import HeadBackIcon from "assets/icons/ico-head-back-circle.svg";
+import { Liquor } from "models/liquor";
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useCallback, useEffect } from "react";
 import { sendMessageToFlutter } from "app/liquor/utils/flutterBridge";
 
 /** 술 상세 컴포넌트 */
-function LiquorDetail({ id }: { id: number }) {
-  const { data: liquor } = useGetLiquorDetail(id);
-  console.log("Fetched Liquor Data:", liquor);
-  console.log("Liquor Material List:", liquor?.liquorMaterialList);
-  console.log("Liquor Recipe:", liquor?.liquorRecipe);
+function LiquorDetail({ liquorData }: { liquorData: Liquor }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [touchStartX, setTouchStartX] = useState<number | null>(null);
-
-  // 표시할 태그 목록
-  const newTags = [
-    liquor.liquorNameDto.name,
-    ...liquor.liquorSellDtos.map((sell) => sell.name),
-    ...liquor.stateTypeDtos.map((state) => state.name),
-    ...liquor.tasteTypeDtos.map((taste) => taste.name),
-  ];
 
   const handleBack = useCallback(() => {
     const fromApp = searchParams.get("source") === "app";
@@ -38,7 +26,6 @@ function LiquorDetail({ id }: { id: number }) {
     } else if (hasHistory) {
       router.back();
     } else {
-      // history가 없는 경우에도 Flutter로 돌아가기
       sendMessageToFlutter();
     }
   }, [searchParams, router]);
@@ -55,24 +42,34 @@ function LiquorDetail({ id }: { id: number }) {
       const diffX = touchEndX - touchStartX;
 
       if (diffX > 100) {
-        // 스와이프 거리가 100px 이상일 때만 동작
         handleBack();
-        setTouchStartX(null); // 스와이프 처리 후 초기화
+        setTouchStartX(null);
       }
     },
     [touchStartX, handleBack],
   );
 
   const handleTouchEnd = useCallback(() => {
-    setTouchStartX(null); // 터치 종료 시 초기화
+    setTouchStartX(null);
   }, []);
 
-  // 컴포넌트 언마운트 시 cleanup
   useEffect(() => {
     return () => {
       setTouchStartX(null);
     };
   }, []);
+
+  if (!liquorData) {
+    return <div>데이터를 불러오는 중입니다...</div>;
+  }
+
+  // 표시할 태그 목록
+  const newTags = [
+    liquorData.liquorNameDto?.name,
+    ...(liquorData.liquorSellDtos?.map((sell) => sell.name) || []),
+    ...(liquorData.stateTypeDtos?.map((state) => state.name) || []),
+    ...(liquorData.tasteTypeDtos?.map((taste) => taste.name) || []),
+  ].filter(Boolean);
 
   return (
     <>
@@ -82,23 +79,26 @@ function LiquorDetail({ id }: { id: number }) {
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
       >
-        <DetailImage name={liquor.name} imgUrl={liquor.liquorPictureUrl} />
+        <DetailImage
+          name={liquorData.name}
+          imgUrl={liquorData.liquorPictureUrl}
+        />
         <div className="absolute left-4 top-4 z-10">
           <HeadBackIcon onClick={handleBack} />
         </div>
       </div>
       <DetailInfo
-        name={liquor.name}
-        detailAbv={liquor.detailAbv}
-        explanation={liquor.detailExplanation}
+        name={liquorData.name}
+        detailAbv={liquorData.detailAbv}
+        explanation={liquorData.detailExplanation}
         tags={newTags}
       />
       <div className="h-2.5 w-full bg-suldak-gray-200" />
-      <DetailSnack snacks={liquor.liquorSnackRes} />
+      <DetailSnack snacks={liquorData.liquorSnackRes} />
       <div className="h-2.5 w-full bg-suldak-gray-200" />
       <DetailRecipe
-        recipe={liquor.liquorRecipe}
-        material={liquor.liquorMaterialList}
+        recipe={liquorData.liquorRecipe}
+        material={liquorData.liquorMaterialList}
       />
     </>
   );


### PR DESCRIPTION
## 스크린샷

<img width="594" alt="스크린샷 2025-05-17 오후 4 35 41" src="https://github.com/user-attachments/assets/b925fff0-921d-4991-b0d8-ae68f74a2b57" />

콘솔로그 스크린샷입니다.

## 변경사항
- [X] 술 상세 페이지에서 api를 중복 호출하는 문제가 있었습니다. 현재님께서 LiquorDetailPage와 LiquorDetail 둘 다 "use client" 지시문을 사용하는 클라이언트 컴포넌트여서 발생하는 문제같으니 ISR을 적용하도록 변경하면 어떠냐는 조언을 해주셨습니다. 그래서 해당 조언을 바탕으로 페이지 컴포넌트를 서버 컴포넌트로 변경했습니다. 그리고 서버 컴포넌트에 쓸 수 있도록 axios가 아닌 fetch API를 사용해 fetchLiquorDetail를 작성했습니다. 또한 ISR의 revaildate 시간은 3600초 (1시간)으로 설정했습니다.